### PR TITLE
Bug Fix: hidden posts not generated

### DIFF
--- a/actions/getPostMetadata.ts
+++ b/actions/getPostMetadata.ts
@@ -13,19 +13,18 @@ const getPostMetadata = (): PostMetadata[] => {
   const files = fs.readdirSync(folder);
   const markdownPosts = files.filter((file) => file.endsWith(".md"));
 
-  const posts: PostMetadata[] = markdownPosts
-    .map((fileName) => {
-      const fileContents = fs.readFileSync(`posts/${fileName}`, "utf8");
-      const matterResult = matter(fileContents);
-      return {
-        title: matterResult.data.title,
-        date: matterResult.data.date,
-        subtitle: matterResult.data.subtitle,
-        slug: fileName.replace(".md", ""),
-        display: matterResult.data.display,
-      };
-    })
-    .filter((post) => post.display !== "false");
+  const posts: PostMetadata[] = markdownPosts.map((fileName) => {
+    const fileContents = fs.readFileSync(`posts/${fileName}`, "utf8");
+    const matterResult = matter(fileContents);
+    return {
+      title: matterResult.data.title,
+      date: matterResult.data.date,
+      subtitle: matterResult.data.subtitle,
+      slug: fileName.replace(".md", ""),
+      display: matterResult.data.display,
+    };
+  });
+  // .filter((post) => post.display !== "false");
 
   return posts;
 };

--- a/actions/getPostMetadata.ts
+++ b/actions/getPostMetadata.ts
@@ -24,7 +24,6 @@ const getPostMetadata = (): PostMetadata[] => {
       display: matterResult.data.display,
     };
   });
-  // .filter((post) => post.display !== "false");
 
   return posts;
 };

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -7,7 +7,12 @@ import PostItem from "@/components/Posts/PostItem";
  * @returns (JSX.Element): page with all posts
  */
 export default function Posts() {
-  const postMetadata = getPostMetadata();
+  let postMetadata = getPostMetadata();
+
+  // Filter posts where display is 'true' or undefined
+  postMetadata = postMetadata.filter(
+    (post) => post.display === "true" || post.display === undefined
+  );
 
   return (
     <main>
@@ -15,7 +20,7 @@ export default function Posts() {
         <div className="my-12 pb-12 md:pt-8 md:pb-48">
           <HeadingOne title="Posts" />
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-14 ">
-            {postMetadata ? (
+            {postMetadata.length > 0 ? (
               postMetadata.map((post) => <PostItem key={post.slug} {...post} />)
             ) : (
               <div className="flex items-center justify-center h-screen">


### PR DESCRIPTION
Opening posts with `display: false` would not get generated as `getPostMetadata` would filter them out and the post slug would generate them meaning the false ones were not statically generated. 
Now the `getPostMetadata` returns all posts, meaning that the post slug would statically generate all markdowns. The post page would instead filter out the hidden posts. 