### PR TITLE
Hid scrollbars from modals

### DIFF
--- a/components/Modal/Modal.tsx
+++ b/components/Modal/Modal.tsx
@@ -78,6 +78,7 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, title }) => {
                   w-full
                   max-h-[70vh] min-h-[70vh]
                   overflow-y-auto
+                  scrollbar-hide
                   sm:my-8 
                   sm:w-full 
                   sm:max-w-lg 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-dom": "18.2.0",
     "react-icons": "^4.9.0",
     "react-scroll": "^1.8.9",
+    "tailwind-scrollbar-hide": "^1.1.7",
     "tailwindcss": "3.3.2",
     "typescript": "5.1.3",
     "zustand": "^4.3.8"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -26,6 +26,9 @@ module.exports = {
         4: "0.4s",
         6: "0.6s",
       },
+      scrollbarHide: {
+        'scrollbar-hide': '::-webkit-scrollbar { display: none; }',
+      },
       keyframes: {
         fadeIn: {
           from: { opacity: 0 },
@@ -44,5 +47,6 @@ module.exports = {
   },
   plugins: [
     require('@tailwindcss/typography'),
+    require('tailwind-scrollbar-hide')
   ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2431,6 +2431,11 @@ synckit@^0.8.5:
     "@pkgr/utils" "^2.3.1"
     tslib "^2.5.0"
 
+tailwind-scrollbar-hide@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/tailwind-scrollbar-hide/-/tailwind-scrollbar-hide-1.1.7.tgz#90b481fb2e204030e3919427416650c54f56f847"
+  integrity sha512-X324n9OtpTmOMqEgDUEA/RgLrNfBF/jwJdctaPZDzB3mppxJk7TLIDmOreEDm1Bq4R9LSPu4Epf8VSdovNU+iA==
+
 tailwindcss@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.3.2.tgz#2f9e35d715fdf0bbf674d90147a0684d7054a2d3"


### PR DESCRIPTION
- Take too much space, don't look good and are not needed
- Installed package and extended Tailwind config