### PR TITLE
BUG FIX: Language all filter not working

### DIFF
--- a/components/Inputs/RadioButton.tsx
+++ b/components/Inputs/RadioButton.tsx
@@ -56,7 +56,6 @@ const RadioButton: React.FC<RadioButtonProps> = ({
 
   return (
     <label
-      htmlFor={id}
       className={combinedClassName}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}


### PR DESCRIPTION
Clicking on other filters would work fine except for the all filter. 