### PR TITLE
BUG FIX: Gallery component causing 404 due to wrong casting

### DIFF
--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -122,7 +122,7 @@ const ProjectPage: React.FC<ProjectPageProps> = ({ params, searchParams }) => {
 
       {/* Gallery Section */}
       {media && media.length > 1 ? (
-        <Gallery mediaItems={media} index={searchParams.index as string} />
+        <Gallery mediaItems={media} index={searchParams.index} />
       ) : project?.imageURL ? (
         <div
           className="

--- a/components/Gallery/Gallery.tsx
+++ b/components/Gallery/Gallery.tsx
@@ -13,7 +13,7 @@ import VideoPlayer from "./VideoPlayer";
 
 interface GalleryProps {
   mediaItems: MediaItem[];
-  index: string; // index of the currently active media item from url
+  index: string | string[] | undefined;
 }
 
 /**
@@ -27,7 +27,7 @@ interface GalleryProps {
  */
 const Gallery: React.FC<GalleryProps> = ({ mediaItems, index }) => {
   const currentIndex = index || "0";
-  const activeIndex = parseInt(currentIndex);
+  const activeIndex = parseInt(currentIndex.toString());
 
   /**
    * Get the first image in the gallery.


### PR DESCRIPTION
- All the project pages that have galleries return 404
- Pages that do not render galleries take you to the correct project page
- This is only an issue in Vercel and not local development or built