### PR TITLE
BUG FIX: Filter page button hover effects broken

### DIFF
--- a/components/Filters/Page/ClearAllFiltersButton.tsx
+++ b/components/Filters/Page/ClearAllFiltersButton.tsx
@@ -26,13 +26,13 @@ const ClearAllFiltersButton: React.FC<ClearAllFiltersButtonProps> = ({
       disabled={!areFiltersApplied}
       className={`
 				px-4 py-2 w-full
-				text-base font-medium text-neutral-700 dark:text-neutral-200 capitalize hover:text-neutral-700 dark:hover:text-neutral-200
+				text-base font-medium text-neutral-700 dark:text-neutral-200 capitalize md:hover:text-neutral-700 dark:md:hover:text-neutral-200
 				rounded-xl
-				shadow-md hover:shadow-lg focus:shadow-lg
+				shadow-md md:hover:shadow-lg focus:shadow-lg
 				bg-neutral-100 dark:bg-neutral-800 
-				hover:bg-neutral-100 dark:hover:bg-neutral-800
+				md:hover:bg-neutral-100 dark:md:hover:bg-neutral-800
 				border-2 border-transparent dark:border-transparent
-				hover:border-red-500 dark:hover:border-red-800
+				md:hover:border-red-500 dark:md:hover:border-red-800
 				transition-all duration-500 ease-in-out
 			`}
     >

--- a/components/Filters/Page/OpenFilterModalButton.tsx
+++ b/components/Filters/Page/OpenFilterModalButton.tsx
@@ -21,13 +21,13 @@ const OpenFilterModalButton: React.FC<OpenFilterModalButtonProps> = ({
       onClick={handleOpenFilterModal}
       className={`
 				px-4 py-2 w-full
-				text-base font-medium text-neutral-700 dark:text-neutral-200 capitalize hover:text-neutral-700 dark:hover:text-neutral-200
+				text-base font-medium text-neutral-700 dark:text-neutral-200 capitalize md:hover:text-neutral-700 dark:md:hover:text-neutral-200
 				rounded-xl
-				shadow-md hover:shadow-lg focus:shadow-lg
+				shadow-md md:hover:shadow-lg focus:shadow-lg
 				bg-neutral-100 dark:bg-neutral-800 
-				hover:bg-neutral-100 dark:hover:bg-neutral-800
+				md:hover:bg-neutral-100 dark:md:hover:bg-neutral-800
 				border-2 border-transparent dark:border-transparent
-				hover:border-red-500 dark:hover:border-red-800
+				md:hover:border-red-500 dark:md:hover:border-red-800
 				transition-all duration-500 ease-in-out
 			`}
     >


### PR DESCRIPTION
- Caused by hover effects only applying on medium sizes on base button component
- These filter buttons were still applying hover effects all the time