### PR TITLE
BUG FIX: Project item adds thumbnail to project

### DIFF
--- a/app/(site)/components/ProjectSection.tsx
+++ b/app/(site)/components/ProjectSection.tsx
@@ -30,7 +30,7 @@ const ProjectsSection = () => {
     return null;
   }
 
-  const updatedProjects = updateProjectImages(allProjects);
+  // const updatedProjects = updateProjectImages(allProjects);
 
   return (
     <section id="projects" className="wrapper ">
@@ -38,19 +38,12 @@ const ProjectsSection = () => {
         <HeadingTwo title="Projects" />
 
         <div className="flex flex-col space-y-20 mt-14">
-          {updatedProjects
+          {allProjects
             .filter((project) => allowedSlugs.includes(project.slug))
             .map((project, idx) => (
               <div key={idx}>
                 <SlideUp offset="-150px 0px -150px 0px">
-                  <ProjectItem
-                    name={project.name}
-                    slug={project.slug}
-                    description={project.description}
-                    imageURL={project.imageURL}
-                    repoURL={project.repoURL}
-                    siteURL={project.siteURL}
-                  />
+                  <ProjectItem project={project} />
                 </SlideUp>
               </div>
             ))}

--- a/app/projects/components/ProjectListSection.tsx
+++ b/app/projects/components/ProjectListSection.tsx
@@ -28,16 +28,7 @@ const ProjectsListSection: React.FC<ProjectsListSectionProps> = ({
                   <div className="space-y-20">
                     {groupedProjects[type].map((project, idx) => (
                       <div key={idx}>
-                        {/* Assuming ProjectItem is a component for individual project items */}
-                        <ProjectItem
-                          name={project.name}
-                          slug={project.slug}
-                          key={project.imageURL}
-                          description={project.description}
-                          imageURL={project.imageURL}
-                          repoURL={project.repoURL}
-                          siteURL={project.siteURL}
-                        />
+                        <ProjectItem project={project} />
                       </div>
                     ))}
                   </div>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -48,14 +48,14 @@ const ProjectsPage = () => {
     ...otherProjects,
   ];
 
-  const updatedProjects = updateProjectImages(allProjects);
+  // const updatedProjects = updateProjectImages(allProjects);
 
   return (
     <section id="projects" className="flex flex-col items-start md:items-end">
       <div className="my-12 pb-12 md:pt-8 md:pb-48 animate-fadeIn animation-delay-2 w-full min-h-[85vh]">
         <HeadingOne title="Projects" />
         <PageDescription description={description} />
-        <ProjectsList allProjects={updatedProjects} />
+        <ProjectsList allProjects={allProjects} />
       </div>
     </section>
   );

--- a/components/ProjectItem/ProjectItem.tsx
+++ b/components/ProjectItem/ProjectItem.tsx
@@ -1,3 +1,4 @@
+import hasProjectCover from "@/actions/hasProjectCover";
 import Project from "@/types/projects";
 import Image from "next/image";
 import Link from "next/link";
@@ -5,12 +6,7 @@ import React from "react";
 import { BsArrowUpRightCircle, BsGithub, BsInfoCircle } from "react-icons/bs";
 
 interface ProjectItemProps {
-  name: string;
-  slug: string;
-  description: string;
-  imageURL?: string;
-  repoURL?: string;
-  siteURL?: string;
+  project: Project;
 }
 
 /**
@@ -40,19 +36,19 @@ interface ProjectItemProps {
  * @param type (string): Type of the project
  * @returns (JSX.Element): Project item component
  */
-const ProjectItem: React.FC<ProjectItemProps> = ({
-  name,
-  slug,
-  description,
-  imageURL,
-  repoURL,
-  siteURL,
-}) => {
+const ProjectItem: React.FC<ProjectItemProps> = ({ project }) => {
+  if (project.hasImage) {
+    project = {
+      ...project,
+      imageURL: `/projects/${project.slug}/cover.png`,
+    };
+  }
+
   return (
     <div className="bg-neutral-100 dark:bg-neutral-950 p-4 rounded-xl sm:bg-white sm:dark:bg-neutral-900 sm:p-0 transition-colors duration-700 ">
       <div className="flex flex-col animate-slideUpCubiBezier animation-delay-2 lg:flex-row lg:space-x-12">
         {/* Project Cover */}
-        {imageURL && (
+        {project.imageURL && (
           <div
             className="
                 lg:w-1/2
@@ -62,11 +58,11 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
                 transition-all duration-500 ease-in-out
               "
           >
-            <Link href={`/projects/${slug}`}>
+            <Link href={`/projects/${project.slug}`}>
               <Image
-                src={imageURL}
-                key={imageURL}
-                alt={`${name} cover image`}
+                src={project.imageURL}
+                key={project.imageURL}
+                alt={`${project.name} cover image`}
                 width={1000}
                 height={1000}
                 quality={40}
@@ -78,9 +74,9 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
           </div>
         )}
 
-        <div className={`mt-8 ${imageURL ? "lg:w-1/2" : "lg:w-full"}`}>
+        <div className={`mt-8 ${project.imageURL ? "lg:w-1/2" : "lg:w-full"}`}>
           {/* Project Title */}
-          <Link href={`/projects/${slug}`}>
+          <Link href={`/projects/${project.slug}`}>
             <h1
               className="
                   flex flex-col
@@ -91,13 +87,13 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
                   transition-colors duration-700 ease-in-out
                 "
             >
-              {name}
+              {project.name}
             </h1>
           </Link>
 
           {/* Project Description */}
           <p className="text-xl text-left leading-7 mb-4 text-neutral-600 dark:text-neutral-400">
-            {description}
+            {project.description}
           </p>
 
           {/* Buttons */}
@@ -109,7 +105,7 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
               space-x-4 mt-8"
           >
             {/* Project Page */}
-            <Link href={`/projects/${slug}`} title="Project Page">
+            <Link href={`/projects/${project.slug}`} title="Project Page">
               <BsInfoCircle
                 size={30}
                 className="md:hover:-translate-y-1 transition-transform cursor-pointer"
@@ -117,8 +113,8 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
             </Link>
 
             {/* Repository */}
-            {repoURL && (
-              <Link href={repoURL} target="_blank" title="Repository">
+            {project.repoURL && (
+              <Link href={project.repoURL} target="_blank" title="Repository">
                 <BsGithub
                   size={30}
                   className="md:hover:-translate-y-1 transition-transform cursor-pointer"
@@ -126,8 +122,8 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
               </Link>
             )}
             {/* Project Website */}
-            {siteURL && (
-              <Link href={siteURL} target="_blank" title="Website">
+            {project.siteURL && (
+              <Link href={project.siteURL} target="_blank" title="Website">
                 <BsArrowUpRightCircle
                   size={30}
                   className="md:hover:-translate-y-1 transition-transform cursor-pointer"

--- a/constants/projects.ts
+++ b/constants/projects.ts
@@ -135,6 +135,7 @@ const webdevProjects: Project[] = [
     ],
     extraTechnicalGeneralSkills: [oop, designPatterns, algorithms],
     type: "Full-Stack Web Development",
+    hasImage: true,
   },
   {
     name: `Ringmaster Messaging`,
@@ -176,6 +177,7 @@ const webdevProjects: Project[] = [
     ],
     extraTechnicalGeneralSkills: [oop, designPatterns, algorithms],
     type: "Full-Stack Web Development",
+    hasImage: true,
   },
   {
     name: `Magician AI`,
@@ -219,6 +221,7 @@ const webdevProjects: Project[] = [
     ],
     extraTechnicalGeneralSkills: [oop, designPatterns, algorithms],
     type: "Full-Stack Web Development",
+    hasImage: true,
   },
   {
     name: `Drumroll Music`,
@@ -254,6 +257,7 @@ const webdevProjects: Project[] = [
     ],
     extraTechnicalGeneralSkills: [oop, designPatterns, algorithms],
     type: "Full-Stack Web Development",
+    hasImage: true,
   },
 ];
 
@@ -300,6 +304,7 @@ const extraWebDevProjects: Project[] = [
     ],
     extraTechnicalGeneralSkills: [oop, designPatterns, algorithms],
     repoURL: "https://github.com/mbeps/quizmify",
+    hasImage: true,
   },
   {
     name: `Sideshow Articles`,
@@ -333,6 +338,7 @@ const extraWebDevProjects: Project[] = [
     extraTechnicalGeneralSkills: [oop],
     type: "Full-Stack Web Development",
     archived: true,
+    hasImage: true,
   },
   {
     name: `Noodle`,
@@ -375,6 +381,7 @@ const extraWebDevProjects: Project[] = [
     ],
     type: "Full-Stack Web Development",
     archived: true,
+    hasImage: true,
   },
   {
     name: `ConvoGPT`,
@@ -751,6 +758,7 @@ const gameDevProjects: Project[] = [
       teamwork,
     ],
     type: "Game Development",
+    hasImage: true,
   },
   {
     name: "Surface Fight",
@@ -772,6 +780,7 @@ const gameDevProjects: Project[] = [
     ],
     siteURL: "https://bepary-games.itch.io/surface-fight",
     archived: true,
+    hasImage: true,
   },
   {
     name: "Platformer",
@@ -794,6 +803,7 @@ const gameDevProjects: Project[] = [
     ],
     siteURL: "https://bepary-games.itch.io/platformer",
     archived: true,
+    hasImage: true,
   },
   {
     name: "Platformer Death Walk",
@@ -816,6 +826,7 @@ const gameDevProjects: Project[] = [
     ],
     siteURL: "https://bepary-games.itch.io/platformer-death-walk",
     archived: true,
+    hasImage: true,
   },
   {
     name: "Coding Breakout",
@@ -837,6 +848,7 @@ const gameDevProjects: Project[] = [
     ],
     siteURL: "https://bepary-games.itch.io/coding-break-out",
     archived: true,
+    hasImage: true,
   },
   {
     name: "Catch Maruf",
@@ -858,6 +870,7 @@ const gameDevProjects: Project[] = [
     ],
     siteURL: "https://bepary-games.itch.io/catch-maruf",
     archived: true,
+    hasImage: true,
   },
   {
     name: "Against Gravity",
@@ -879,6 +892,7 @@ const gameDevProjects: Project[] = [
     ],
     siteURL: "https://bepary-games.itch.io/against-gravity",
     archived: true,
+    hasImage: true,
   },
   {
     name: "Scrolling Shooter",
@@ -899,6 +913,7 @@ const gameDevProjects: Project[] = [
     ],
     siteURL: "https://bepary-games.itch.io/scrolling-shooter",
     archived: true,
+    hasImage: true,
   },
   {
     name: "Dungeon",
@@ -919,6 +934,7 @@ const gameDevProjects: Project[] = [
     ],
     siteURL: "https://bepary-games.itch.io/dungeon-",
     archived: true,
+    hasImage: true,
   },
   {
     name: " Veg Ninja",
@@ -940,6 +956,7 @@ const gameDevProjects: Project[] = [
     ],
     siteURL: "https://bepary-games.itch.io/vej-ninja",
     archived: true,
+    hasImage: true,
   },
   {
     name: " Angry Cats Space",
@@ -961,6 +978,7 @@ const gameDevProjects: Project[] = [
     ],
     siteURL: "https://bepary-games.itch.io/angry-cats-space",
     archived: true,
+    hasImage: true,
   },
   {
     name: " Angry Cats",
@@ -982,6 +1000,7 @@ const gameDevProjects: Project[] = [
     ],
     siteURL: "https://bepary-games.itch.io/angry-cats-space",
     archived: true,
+    hasImage: true,
   },
 ];
 

--- a/types/projects.ts
+++ b/types/projects.ts
@@ -7,9 +7,6 @@ export default interface Project {
   name: string;
   slug: string;
   description: string;
-  imageURL?: string;
-  repoURL?: string;
-  siteURL?: string;
   programmingLanguage: Skill;
   technologySkills: Skill[];
   extraTechnicalGeneralSkills?: Skill[];
@@ -21,5 +18,9 @@ export default interface Project {
     | "Java Assignments"
     | "Game Development"
     | "Other";
+  repoURL?: string;
+  siteURL?: string;
+  imageURL?: string; // added dynamically from file system
+  hasImage?: boolean; // used for adding image path to imageURL
   archived?: boolean;
 }


### PR DESCRIPTION
- Means that pages do not have to add thumbnails each time reducing codebase and errors (forgetting to add images)
- Theoretically works on serverless as the existence of the image is not being checked using the file system (not available in serverless)
- Single place to add thumbnails to projects instead of doing it from multiple places