### PR TITLE
Language Tags not Clickable on Home Page

### DIFF
--- a/app/(site)/components/AboutSection/LanguageSection.tsx
+++ b/app/(site)/components/AboutSection/LanguageSection.tsx
@@ -23,19 +23,6 @@ const LanguageSection: React.FC = () => {
     setIsModalOpen(false);
   };
 
-  /**
-   * Gets the list of skills for a language if it exists.
-   * Languages that do not have skills are not clickable.
-   * @param languageName (string): name of the language to get the skills for
-   * @returns (Skill[]): list of skills for the language (empty array if the language does not exist)
-   */
-  const getSkillsByLanguage = (languageName: string): Skill[] => {
-    const language = languages.find((lang) => lang.name === languageName);
-    return language && language.technicalGeneralSkills
-      ? language.technicalGeneralSkills
-      : [];
-  };
-
   const mainLanguages = languages.filter((lang) => lang.isMainSkill);
 
   return (
@@ -46,7 +33,6 @@ const LanguageSection: React.FC = () => {
           <LanguageTagWithModal
             key={idx}
             language={languageData}
-            skills={getSkillsByLanguage(languageData.name)}
             handleOpenModal={handleOpenModal}
             handleCloseModal={handleCloseModal}
             isModalOpen={isModalOpen}
@@ -61,7 +47,6 @@ export default LanguageSection;
 
 interface LanguageTagWithModalProps {
   language: Skill;
-  skills: Skill[];
   repository?: string;
   handleOpenModal: () => void;
   handleCloseModal: () => void;
@@ -81,7 +66,6 @@ interface LanguageTagWithModalProps {
  */
 const LanguageTagWithModal: React.FC<LanguageTagWithModalProps> = ({
   language,
-  skills,
   repository,
 }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -94,7 +78,7 @@ const LanguageTagWithModal: React.FC<LanguageTagWithModalProps> = ({
     setIsModalOpen(false);
   };
 
-  const shouldOpenModal = skills.length > 0 || repository;
+  const shouldOpenModal = language.technicalHardSkills && language.technicalHardSkills.length > 0;
 
   return (
     <>
@@ -106,7 +90,7 @@ const LanguageTagWithModal: React.FC<LanguageTagWithModalProps> = ({
           isOpen={isModalOpen}
           onClose={handleCloseModal}
           language={language}
-          skills={skills}
+          skills={language.technicalHardSkills!}
         />
       )}
     </>

--- a/components/Modal/LanguageModal.tsx
+++ b/components/Modal/LanguageModal.tsx
@@ -35,16 +35,13 @@ interface ProjectModalProps {
  * @returns (JSX.Element): modal component (stack of the project
  */
 const LanguageModal: React.FC<ProjectModalProps> = ({
-  skills,
   language,
   isOpen,
   onClose,
 }) => {
   const [groupedBy, setGroupedBy] = useState("category");
-  const groupedSkills = groupSkills(
-    groupedBy,
-    language.technicalGeneralSkills || []
-  );
+  const filteredSkills = (language.technicalHardSkills || []).filter(skill => skill.isMainSkill);
+  const groupedSkills = groupSkills(groupedBy, filteredSkills);
 
   const projects = allProjects;
   const certificates = allCertificates;

--- a/components/Modal/LanguageModal.tsx
+++ b/components/Modal/LanguageModal.tsx
@@ -40,8 +40,13 @@ const LanguageModal: React.FC<ProjectModalProps> = ({
   onClose,
 }) => {
   const [groupedBy, setGroupedBy] = useState("category");
-  const filteredSkills = (language.technicalHardSkills || []).filter(skill => skill.isMainSkill);
-  const groupedSkills = groupSkills(groupedBy, language.technicalHardSkills || []);
+  const filteredSkills = (language.technicalHardSkills || []).filter(
+    (skill) => skill.isMainSkill,
+  );
+  const groupedSkills = groupSkills(
+    groupedBy,
+    language.technicalHardSkills || [],
+  );
 
   const projects = allProjects;
   const certificates = allCertificates;
@@ -50,7 +55,7 @@ const LanguageModal: React.FC<ProjectModalProps> = ({
   const hasProjects = isSkillAssociatedWithProject(language, projects);
   const hasCertificates = isSkillAssociatedWithCertificate(
     language,
-    certificates
+    certificates,
   );
   const hasBlogs = isSkillAssociatedWithBlogs(language, allBlogs);
   const hasMaterial = hasProjects || hasCertificates || hasBlogs;
@@ -71,6 +76,7 @@ const LanguageModal: React.FC<ProjectModalProps> = ({
         />
       </div>
 
+      {/* List of skills */}
       {Object.entries(groupedSkills).map(([category, skills], index) => (
         <div key={index} className="mt-4 text-center md:text-left">
           <HeadingThree title={category} />
@@ -82,10 +88,34 @@ const LanguageModal: React.FC<ProjectModalProps> = ({
         </div>
       ))}
 
+      {/* Links */}
       {hasMaterial && (
         <div className="text-center md:text-left">
           <HeadingThree title="Material" />
         </div>
+      )}
+      {hasMaterial && (
+        <>
+          <div
+            className="
+            flex flex-wrap flex-col 
+            text-center md:text-left 
+            justify-start z-10 mt-5 space-y-2"
+          >
+            <Link
+              href={`
+            /skills/${language.slug}
+            `}
+            >
+              <div className="w-full">
+                <Button
+                  variant="gradient"
+                  className="w-full"
+                >{`All ${language.name} Material`}</Button>
+              </div>
+            </Link>
+          </div>
+        </>
       )}
       {hasProjects && (
         <div
@@ -147,30 +177,6 @@ const LanguageModal: React.FC<ProjectModalProps> = ({
             </div>
           </Link>
         </div>
-      )}
-
-      {hasMaterial && (
-        <>
-          <div
-            className="
-            flex flex-wrap flex-col 
-            text-center md:text-left 
-            justify-start z-10 mt-5 space-y-2"
-          >
-            <Link
-              href={`
-            /skills/${language.slug}
-            `}
-            >
-              <div className="w-full">
-                <Button
-                  variant="ghost"
-                  className="w-full"
-                >{`All ${language.name} Material`}</Button>
-              </div>
-            </Link>
-          </div>
-        </>
       )}
     </Modal>
   );

--- a/components/Modal/LanguageModal.tsx
+++ b/components/Modal/LanguageModal.tsx
@@ -41,7 +41,7 @@ const LanguageModal: React.FC<ProjectModalProps> = ({
 }) => {
   const [groupedBy, setGroupedBy] = useState("category");
   const filteredSkills = (language.technicalHardSkills || []).filter(skill => skill.isMainSkill);
-  const groupedSkills = groupSkills(groupedBy, filteredSkills);
+  const groupedSkills = groupSkills(groupedBy, language.technicalHardSkills || []);
 
   const projects = allProjects;
   const certificates = allCertificates;


### PR DESCRIPTION
- Cleaned code by removing unnecessary props
- Made language tags clickable to open modal to show language related skills like before
- Display all skills related to that language 
- Made all material button within language modal more prominent but putting it at the top and using gradient button variant 