### PR TITLE
Only show project type in the projects page

### DIFF
--- a/app/projects/components/ProjectsView.tsx
+++ b/app/projects/components/ProjectsView.tsx
@@ -269,7 +269,7 @@ const ProjectsView: React.FC = () => {
       />
 
       {/* List of projects */}
-      <ProjectsList groupedMaterial={groupedProjects} />
+      <ProjectsList groupedMaterial={groupedProjects} showType={true} />
     </>
   );
 };

--- a/components/MaterialItems/CourseItem.tsx
+++ b/components/MaterialItems/CourseItem.tsx
@@ -26,27 +26,27 @@ const CourseItem: React.FC<CourseItemProps> = ({ courseKey }) => {
         bg-neutral-100 dark:bg-neutral-800
         border border-neutral-300 dark:border-neutral-700
         shadow-md
-        p-3 lg:p-6 rounded-xl
+        p-3 rounded-xl
         transition-colors duration-700
-        flex flex-col
+        flex flex-col lg:grid lg:grid-cols-3
         animate-slideUpCubiBezier animation-delay-2
         h-full w-full
       "
     >
       {/* Certificate Image */}
       {courseData.certificate && (
-        <Link href={`education/${courseKey}`}>
+        <Link href={`education/${courseKey}`} className="lg:col-span-1">
           <div
             className="
-            flex justify-center
-            rounded-xl
-            transform md:hover:scale-105
-            shadow-sm md:hover:shadow-lg
-            transition-all duration-500 ease-in-out
-            mb-6
-            w-full
-            overflow-hidden
-        "
+              flex justify-center
+              rounded-xl
+              transform md:hover:scale-105
+              shadow-sm md:hover:shadow-lg
+              transition-all duration-500 ease-in-out
+              mb-6
+              w-full
+              overflow-hidden
+            "
           >
             <AspectRatio ratio={1 / 1.4} className="overflow-hidden relative">
               <Image
@@ -60,7 +60,7 @@ const CourseItem: React.FC<CourseItemProps> = ({ courseKey }) => {
                   rounded-xl
                   cursor-pointer
                   object-cover
-              "
+                "
               />
             </AspectRatio>
           </div>
@@ -69,28 +69,33 @@ const CourseItem: React.FC<CourseItemProps> = ({ courseKey }) => {
 
       <div
         className="
-        flex flex-col 
-        gap-5 px-4 py-4"
+          flex flex-col 
+          gap-5 px-4 py-4
+          lg:col-span-2
+          space-y-4
+        "
       >
-        {/* Certificate Title */}
-        <Link href={`education/${courseKey}`}>
-          <h1
-            className="
-              text-3xl md:text-4xl font-bold text-center 
-              md:hover:text-red-500 md:dark:hover:text-red-800
-              transition-colors duration-700 ease-in-out
+        <div className="lg:w-full lg:text-left">
+          {/* Certificate Title */}
+          <Link href={`education/${courseKey}`}>
+            <h1
+              className="
+                text-3xl md:text-4xl font-bold text-center lg:text-left
+                md:hover:text-red-500 md:dark:hover:text-red-800
+                transition-colors duration-700 ease-in-out
               "
-          >
-            {courseData.name}
-          </h1>
-        </Link>
+            >
+              {courseData.name}
+            </h1>
+          </Link>
 
-        <p className="text-xl text-center leading-7 text-neutral-600 dark:text-neutral-400">
-          {courseData.grade}
-        </p>
+          <p className="text-xl text-center lg:text-left leading-7 text-neutral-600 dark:text-neutral-400">
+            {courseData.grade}
+          </p>
 
-        <div className="w-full flex justify-center">
-          <Tag>{courseData.university}</Tag>
+          <div className="w-full flex justify-center lg:justify-start">
+            <Tag>{courseData.university}</Tag>
+          </div>
         </div>
       </div>
     </div>

--- a/components/MaterialItems/ProjectItem.tsx
+++ b/components/MaterialItems/ProjectItem.tsx
@@ -14,6 +14,7 @@ import projectDatabaseMap from "@/database/Projects/ProjectDatabaseMap";
 
 interface ProjectItemProps {
   projectKey: string;
+  showType?: boolean;
 }
 
 /**
@@ -33,7 +34,10 @@ interface ProjectItemProps {
  * @param projectKey Key of the project to be displayed
  * @returns A card which displays a project
  */
-const ProjectItem: React.FC<ProjectItemProps> = ({ projectKey }) => {
+const ProjectItem: React.FC<ProjectItemProps> = ({
+  projectKey,
+  showType = false,
+}) => {
   const basePath: string = PROJECTS_PAGE.path;
   const projectData: ProjectInterface = projectDatabaseMap[projectKey];
   const linkStyle: string =
@@ -114,19 +118,21 @@ const ProjectItem: React.FC<ProjectItemProps> = ({ projectKey }) => {
           </Link>
 
           {/* Project Type */}
-          <p
-            className="
-              mb-2 
-              italic font-medium
-              text-red-700 dark:text-red-300
-              text-center lg:text-left
-            "
-          >
-            {`${projectData.type} Project`}
-          </p>
+          {showType && (
+            <p
+              className="
+                italic font-medium
+                text-red-700 dark:text-red-300
+                text-center lg:text-left
+                -mb-2
+              "
+            >
+              {`${projectData.type} Project`}
+            </p>
+          )}
 
           {/* Project Description */}
-          <p className="text-xl text-left leading-7 mb-4 text-neutral-600 dark:text-neutral-400">
+          <p className="text-xl text-left leading-7 mt-4 mb-4 text-neutral-600 dark:text-neutral-400">
             {projectData.description}
           </p>
 

--- a/components/MaterialLists/ProjectsList.tsx
+++ b/components/MaterialLists/ProjectsList.tsx
@@ -3,6 +3,10 @@ import ProjectItem from "@/components/MaterialItems/ProjectItem";
 import HeadingTwo from "@/components/Text/HeadingTwo";
 import MaterialListProps from "@/interfaces/props/MaterialListProps";
 
+interface ExtendedMaterialListProps extends MaterialListProps {
+  showType?: boolean;
+}
+
 /**
  * List of projects grouped by category to be displayed section by section.
  * Each section contains a title and a list of projects.
@@ -11,8 +15,9 @@ import MaterialListProps from "@/interfaces/props/MaterialListProps";
  * @param groupedProjects List of projects grouped by category to be displayed section by section
  * @returns A list of projects grouped by category
  */
-const ProjectsList: React.FC<MaterialListProps> = ({
+const ProjectsList: React.FC<ExtendedMaterialListProps> = ({
   groupedMaterial: groupedProjects,
+  showType = false,
 }) => {
   return (
     <div className="material-page-wrapper">
@@ -34,7 +39,10 @@ const ProjectsList: React.FC<MaterialListProps> = ({
                         key={projectKey}
                         className="animate-slideUpCubiBezier animation-delay-1"
                       >
-                        <ProjectItem projectKey={projectKey} />
+                        <ProjectItem
+                          projectKey={projectKey}
+                          showType={showType}
+                        />
                       </div>
                     ))}
                   </div>


### PR DESCRIPTION
- Other pages do not need to specify the type of project as it is irrelevant or obvious