### PR TITLE
FIX: Images not being shown in blogs

### DIFF
--- a/constants/paths.ts
+++ b/constants/paths.ts
@@ -34,7 +34,7 @@ export const PATHS = {
     COVER: `${PROJECTS_BASE}/${projectKey}/cover.png`,
     FEATURES: `public${PROJECTS_BASE}/${projectKey}/features.md`,
     BLOG: `public${PROJECTS_BASE}/${projectKey}/blog.md`,
-    BLOG_IMG: `${PROJECTS_BASE.slice(1)}/${projectKey}/img`,
+    BLOG_IMG: `${PROJECTS_BASE}/${projectKey}/img`,
     MEDIA: {
       NORMAL: `${PROJECTS_BASE}/${projectKey}/media`,
       PUBLIC: `public${PROJECTS_BASE}/${projectKey}/media`,
@@ -51,6 +51,6 @@ export const PATHS = {
   }),
   BLOGS: (blogKey: BlogDatabaseKeys) => ({
     BLOG: `public${BLOGS_BASE}/${blogKey}/blog.md`,
-    IMG: `${BLOGS_BASE.slice(1)}/${blogKey}/img`,
+    IMG: `${BLOGS_BASE}/${blogKey}/img`,
   }),
 } as const;


### PR DESCRIPTION
This pull request updates the `PATHS` constants in `constants/paths.ts` to correct the paths for blog and project image directories. The main change is to ensure that image paths are consistent and no longer remove the leading slash, which could cause incorrect path resolution.

Path correction improvements:

* Updated `BLOG_IMG` in the `PROJECTS` paths to use the full `PROJECTS_BASE` path, ensuring the leading slash is preserved.
* Updated `IMG` in the `BLOGS` paths to use the full `BLOGS_BASE` path, ensuring the leading slash is preserved.